### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 build/
+out/
 
 .vscode/
+.vs/
 
 .DS_Store
 .DS_Store?


### PR DESCRIPTION
.gitignore: Visual Studio 2019
new branch: monotty-edition
