### PR TITLE
Exclude "decorative" glyphs from the generated '.ttf' and sort encoding slots while saving `.sfd`

### DIFF
--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -1340,6 +1340,10 @@ static int AssignTTFGlyph(struct glyphinfo *gi,SplineFont *sf,EncMap *map,int is
     for ( i=0; i<map->enccount; ++i ) if ( map->map[i]!=-1 ) {
 	SplineChar *sc = sf->glyphs[map->map[i]];
 	if ( SCWorthOutputting(sc) && sc->ttf_glyph==-1
+
+		//todo monotty unify
+		&& sc->glyph_class != 1 /* No class */
+
 #if HANYANG
 		&& (!iscff || !sc->compositionunit)
 #endif
@@ -1352,6 +1356,10 @@ static int AssignTTFGlyph(struct glyphinfo *gi,SplineFont *sf,EncMap *map,int is
     for ( i=0; i<sf->glyphcnt; ++i ) if ( sf->glyphs[i]!=NULL ) {
 	SplineChar *sc = sf->glyphs[i];
 	if ( SCWorthOutputting(sc) && sc->ttf_glyph==-1
+
+		//todo monotty unify
+		&& sc->glyph_class != 1 /* No class */
+
 #if HANYANG
 		&& (!iscff || !sc->compositionunit)
 #endif
@@ -5619,233 +5627,270 @@ static void buildtablestructures(struct alltabs *at, SplineFont *sf,
     at->tabdir.rangeShift = at->tabdir.numtab*16-at->tabdir.searchRange;
 }
 
-static int initTables(struct alltabs *at, SplineFont *sf,enum fontformat format,
-	int32 *bsizes, enum bitmapformat bf) {
-    int i, j, aborted, offset;
-    BDFFont *bdf;
-    struct ttf_table *tab;
+static int initTables(struct alltabs* at, SplineFont* sf, enum fontformat format,
+	int32* bsizes, enum bitmapformat bf)
+{
+	int i, j, aborted, offset;
+	BDFFont* bdf;
+	struct ttf_table* tab;
 
-   if ( strmatch(at->map->enc->enc_name,"symbol")==0 && format==ff_ttf )
-  	format = ff_ttfsym;
+	if (strmatch(at->map->enc->enc_name, "symbol") == 0 && format == ff_ttf)
+		format = ff_ttfsym;
 
-    tab = SFFindTable(sf,CHR('c','v','t',' '));
-    if ( tab!=NULL ) {
-	at->oldcvt = tab;
-	at->oldcvtlen = tab->len;
-    }
-
-    SFDefaultOS2Info(&sf->pfminfo,sf,sf->fontname);
-
-    at->gi.xmin = at->gi.ymin = 15000;
-    at->gi.sf = sf;
-    if ( bf!=bf_ttf && bf!=bf_sfnt_dfont && bf!=bf_otb && bf!=bf_sfnt_ms )
-	bsizes = NULL;
-    if ( bsizes!=NULL ) {
-	for ( i=j=0; bsizes[i]!=0; ++i ) {
-	    for ( bdf=sf->bitmaps; bdf!=NULL && (bdf->pixelsize!=(bsizes[i]&0xffff) || BDFDepth(bdf)!=(bsizes[i]>>16)); bdf=bdf->next );
-	    if ( bdf!=NULL )
-		bsizes[j++] = bsizes[i];
-	    else
-		ff_post_error(_("Missing bitmap strike"), _("The font database does not contain a bitmap of size %d and depth %d"), bsizes[i]&0xffff, bsizes[i]>>16 );
+	tab = SFFindTable(sf, CHR('c', 'v', 't', ' '));
+	if (tab != NULL)
+	{
+		at->oldcvt = tab;
+		at->oldcvtlen = tab->len;
 	}
-	bsizes[j] = 0;
-	for ( i=0; bsizes[i]!=0; ++i );
-	at->gi.strikecnt = i;
-	if ( i==0 ) bsizes=NULL;
-    }
 
-    if ( sf->subfonts!=NULL ) {
-	SFDummyUpCIDs(&at->gi,sf);	/* life is easier if we ignore the separate fonts of a cid keyed fonts and treat it as flat */
-    } else if ( format!=ff_none )
-	AssignTTFGlyph(&at->gi,sf,at->map,format==ff_otf);
-    else {
-	if ( bsizes==NULL ) {
-	    ff_post_error(_("No bitmap strikes"), _("No bitmap strikes"));
-	    AbortTTF(at,sf);
-return( false );
+	SFDefaultOS2Info(&sf->pfminfo, sf, sf->fontname);
+
+	at->gi.xmin = at->gi.ymin = 15000;
+	at->gi.sf = sf;
+	if (bf != bf_ttf && bf != bf_sfnt_dfont && bf != bf_otb && bf != bf_sfnt_ms)
+		bsizes = NULL;
+	if (bsizes != NULL)
+	{
+		for (i = j = 0; bsizes[i] != 0; ++i)
+		{
+			for (bdf = sf->bitmaps; bdf != NULL && (bdf->pixelsize != (bsizes[i] & 0xffff) || BDFDepth(bdf) != (bsizes[i] >> 16)); bdf = bdf->next);
+			if (bdf != NULL)
+				bsizes[j++] = bsizes[i];
+			else
+				ff_post_error(_("Missing bitmap strike"), _("The font database does not contain a bitmap of size %d and depth %d"), bsizes[i] & 0xffff, bsizes[i] >> 16);
+		}
+		bsizes[j] = 0;
+		for (i = 0; bsizes[i] != 0; ++i);
+		at->gi.strikecnt = i;
+		if (i == 0) bsizes = NULL;
 	}
-	AssignTTFBitGlyph(&at->gi,sf,at->map,bsizes);
-    }
-    if ( at->gi.gcnt>65535 ) {
-	ff_post_error(_("Too many glyphs"), _("The 'sfnt' format is currently limited to 65535 glyphs, and your font has %d of them."),
-		at->gi.gcnt );
-	AbortTTF(at,sf);
-return( false );
-    } else if ( at->gi.gcnt==65535 ) {
-        /* GID 65535 is used as a "No Glyph" mark in many places (cmap tables, mac substitutions to delete a glyph */
-        LogError(_("Your font has exactly 65535 glyphs. Encoding 65535 is the limit and is often used as a magic \
+
+	if (sf->subfonts != NULL)
+	{
+		SFDummyUpCIDs(&at->gi, sf);	/* life is easier if we ignore the separate fonts of a cid keyed fonts and treat it as flat */
+	}
+	else if (format != ff_none)
+	{
+		AssignTTFGlyph(&at->gi, sf, at->map, format == ff_otf);
+	}
+	else
+	{
+		if (bsizes == NULL)
+		{
+			ff_post_error(_("No bitmap strikes"), _("No bitmap strikes"));
+			AbortTTF(at, sf);
+			return(false);
+		}
+		AssignTTFBitGlyph(&at->gi, sf, at->map, bsizes);
+	}
+
+	if (at->gi.gcnt > 65535)
+	{
+		ff_post_error(_("Too many glyphs"), _("The 'sfnt' format is currently limited to 65535 glyphs, and your font has %d of them."),
+			at->gi.gcnt);
+		AbortTTF(at, sf);
+		return(false);
+	}
+	else if (at->gi.gcnt == 65535)
+	{
+		/* GID 65535 is used as a "No Glyph" mark in many places (cmap tables, mac substitutions to delete a glyph */
+		LogError(_("Your font has exactly 65535 glyphs. Encoding 65535 is the limit and is often used as a magic \
             value, so it may cause quirks.\n"));
-    }
-
-
-    ATmaxpInit(at,sf,format);
-    if ( format==ff_otf )
-	aborted = !dumptype2glyphs(sf,at);
-    else if ( format==ff_otfcid )
-	aborted = !dumpcidglyphs(sf,at);
-    else if ( format==ff_none && at->applebitmaps ) {
-	aborted = !dumpcffhmtx(at,sf,true);	/* There is no 'hmtx' table for apple bitmap only fonts */
-		/* But we need some of the side effects of this */
-    } else if ( format==ff_none && at->otbbitmaps ) {
-	aborted = !dumpcffhmtx(at,sf,true);
-	dumpnoglyphs(&at->gi);
-    } else if ( format==ff_none && at->msbitmaps ) {
-	aborted = !dumpglyphs(sf,&at->gi);
-    } else {
-	/* if format==ff_none the following will put out lots of space glyphs */
-	aborted = !dumpglyphs(sf,&at->gi);
-    }
-    if ( format!=ff_type42 && format!=ff_type42cid ) {
-	if ( bsizes!=NULL && !aborted )
-	    ttfdumpbitmap(sf,at,bsizes);
-	if ( bsizes!=NULL && format==ff_none && at->msbitmaps )
-	    ttfdumpbitmapscaling(sf,at,bsizes);
-    }
-    if ( aborted ) {
-	AbortTTF(at,sf);
-return( false );
-    }
-
-    sethead(&at->head,sf,at,format,bsizes);
-    sethhead(&at->hhead,&at->vhead,at,sf);
-    if ( format==ff_none && at->otbbitmaps )
-	dummyloca(at);
-    else if ( format!=ff_otf && format!=ff_otfcid && bf!=bf_sfnt_dfont &&
-	    (format!=ff_none || (bsizes!=NULL && !at->applemode && at->opentypemode)) )
-	redoloca(at);
-    redohead(at);
-    if ( format!=ff_none || !at->applemode )	/* No 'hhea' table for apple bitmap-only fonts */
-	redohhead(at,false);
-    if ( sf->hasvmetrics ) {
-	redohhead(at,true);
-    }
-    ttf_fftm_dump(sf,at);
-
-    if ( format!=ff_type42 && format!=ff_type42cid && !sf->internal_temp ) {
-	initATTables(at, sf, format);
-    }
-    redomaxp(at,format);
-    if ( format!=ff_otf && format!=ff_otfcid && format!=ff_none ) {
-	if (( sf->gasp_cnt!=0 || !SFHasInstructions(sf))
-		&& format!=ff_type42 && format!=ff_type42cid )
-	    dumpgasp(at, sf);
-	at->fpgmf = dumpstoredtable(sf,CHR('f','p','g','m'),&at->fpgmlen);
-	at->prepf = dumpstoredtable(sf,CHR('p','r','e','p'),&at->preplen);
-	at->cvtf = dumpstoredtable(sf,CHR('c','v','t',' '),&at->cvtlen);
-    }
-    for ( tab=sf->ttf_tab_saved; tab!=NULL; tab=tab->next )
-	tab->temp = dumpsavedtable(tab);
-    if ( format!=ff_type42 && format!=ff_type42cid ) {
-	dumppost(at,sf,format);
-	dumpcmap(at,sf,format);
-
-	pfed_dump(at,sf);
-	tex_dump(at,sf);
-    }
-    if ( sf->subfonts!=NULL ) {
-	free(sf->glyphs); sf->glyphs = NULL;
-	sf->glyphcnt = sf->glyphmax = 0;
-    }
-    free( at->gi.bygid );
-    at->gi.gcnt = 0;
-
-    buildtablestructures(at,sf,format);
-    for ( i=0; i<at->tabdir.numtab; ++i ) {
-	struct taboff *tab = &at->tabdir.tabs[i];
-	at->tabdir.ordered[i] = tab;
-	at->tabdir.alpha[i] = tab;
-/* This is the ordering of tables in ARIAL. I've no idea why it makes a */
-/*  difference to order them, time to do a seek seems likely to be small, but */
-/*  other people make a big thing about ordering them so I'll do it. */
-/* I got bored after glyph. Adobe follows the same scheme for their otf fonts */
-/*  so at least the world is consistant */
-/* On the other hand, MS Font validator has a different idea. Oh well */
-/* From: http://partners.adobe.com/asn/tech/type/opentype/recom.jsp	      */
-/* TrueType Ordering							      */
-/*  head, hhea, maxp, OS/2, hmtx, LTSH, VDMX, hdmx, cmap, fpgm, prep, cvt,    */
-/*  loca, glyf, kern, name, post, gasp, PCLT, DSIG			      */
-/* CFF in OpenType Ordering						      */
-/*  head, hhea, maxp, OS/2, name, cmap, post, CFF, (other tables, as convenient) */
-	if ( format==ff_otf || format==ff_otfcid ) {
-	    tab->orderingval = tab->tag==CHR('h','e','a','d')? 1 :
-			       tab->tag==CHR('h','h','e','a')? 2 :
-			       tab->tag==CHR('m','a','x','p')? 3 :
-			       tab->tag==CHR('O','S','/','2')? 4 :
-			       tab->tag==CHR('n','a','m','e')? 5 :
-			       tab->tag==CHR('c','m','a','p')? 6 :
-			       tab->tag==CHR('p','o','s','t')? 7 :
-			       tab->tag==CHR('C','F','F',' ')? 8 :
-			       tab->tag==CHR('G','D','E','F')? 17 :
-			       tab->tag==CHR('G','S','U','B')? 18 :
-			       tab->tag==CHR('G','P','O','S')? 19 :
-			       20;
-	} else {
-	    tab->orderingval = tab->tag==CHR('h','e','a','d')? 1 :
-			       tab->tag==CHR('h','h','e','a')? 2 :
-			       tab->tag==CHR('m','a','x','p')? 3 :
-			       tab->tag==CHR('O','S','/','2')? 4 :
-			       tab->tag==CHR('h','m','t','x')? 5 :
-			       tab->tag==CHR('L','T','S','H')? 6 :
-			       tab->tag==CHR('V','D','M','X')? 7 :
-			       tab->tag==CHR('h','d','m','x')? 8 :
-			       tab->tag==CHR('c','m','a','p')? 9 :
-			       tab->tag==CHR('f','p','g','m')? 10 :
-			       tab->tag==CHR('p','r','e','p')? 11 :
-			       tab->tag==CHR('c','v','t',' ')? 12 :
-			       tab->tag==CHR('l','o','c','a')? 13 :
-			       tab->tag==CHR('g','l','y','f')? 14 :
-			       tab->tag==CHR('k','e','r','n')? 15 :
-			       tab->tag==CHR('n','a','m','e')? 16 :
-			       tab->tag==CHR('p','o','s','t')? 17 :
-			       tab->tag==CHR('g','a','s','p')? 18 :
-			       tab->tag==CHR('P','C','L','T')? 19 :
-			       tab->tag==CHR('D','S','I','G')? 20 :
-			       tab->tag==CHR('G','D','E','F')? 21 :
-			       tab->tag==CHR('G','S','U','B')? 22 :
-			       tab->tag==CHR('G','P','O','S')? 23 :
-			       24;
-	    }
-       }
-
-    qsort(at->tabdir.ordered,at->tabdir.numtab,sizeof(struct taboff *),tcomp);
-    qsort(at->tabdir.alpha,i,sizeof(struct taboff *),tagcomp);
-
-    offset = sizeof(int32)+4*sizeof(int16) + at->tabdir.numtab*4*sizeof(int32);
-    for ( i=0; i<at->tabdir.numtab; ++i ) if ( at->tabdir.ordered[i]->data!=NULL ) {
-	at->tabdir.ordered[i]->offset = offset;
-	offset += ((at->tabdir.ordered[i]->length+3)>>2)<<2;
-	at->tabdir.ordered[i]->checksum = filechecksum(at->tabdir.ordered[i]->data);
-    }
-    for ( i=0; i<at->tabdir.numtab; ++i ) if ( at->tabdir.ordered[i]->data==NULL ) {
-	struct taboff *tab = &at->tabdir.tabs[at->tabdir.ordered[i]->dup_of];
-	at->tabdir.ordered[i]->offset = tab->offset;
-	at->tabdir.ordered[i]->checksum = tab->checksum;
-    }
-
-    tab = SFFindTable(sf,CHR('c','v','t',' '));
-    if ( tab!=NULL ) {
-	if ( at->oldcvt!=NULL && at->oldcvtlen<tab->len )
-	    tab->len = at->oldcvtlen;
-	else if ( at->oldcvt==NULL ) {
-	    /* We created a cvt table when we output the .notdef glyph */
-	    /*  now that means AutoInstr thinks it no longer has a blank */
-	    /*  slate to work with, and will complain, much to the user's */
-	    /*  surprise.  So get rid of it */
-	    struct ttf_table *prev = NULL;
-	    for ( tab = sf->ttf_tables; tab!=NULL ; prev = tab, tab=tab->next )
-		if ( tab->tag==CHR('c','v','t',' ') )
-	    break;
-	    if ( tab!=NULL ) {
-		if ( prev==NULL )
-		    sf->ttf_tables = tab->next;
-		else
-		    prev->next = tab->next;
-		tab->next = NULL;
-		TtfTablesFree(tab);
-	    }
 	}
-    }
-return( true );
+
+
+	ATmaxpInit(at, sf, format);
+	if (format == ff_otf)
+		aborted = !dumptype2glyphs(sf, at);
+	else if (format == ff_otfcid)
+		aborted = !dumpcidglyphs(sf, at);
+	else if (format == ff_none && at->applebitmaps)
+	{
+		aborted = !dumpcffhmtx(at, sf, true);	/* There is no 'hmtx' table for apple bitmap only fonts */
+			/* But we need some of the side effects of this */
+	}
+	else if (format == ff_none && at->otbbitmaps)
+	{
+		aborted = !dumpcffhmtx(at, sf, true);
+		dumpnoglyphs(&at->gi);
+	}
+	else if (format == ff_none && at->msbitmaps)
+	{
+		aborted = !dumpglyphs(sf, &at->gi);
+	}
+	else
+	{
+		/* if format==ff_none the following will put out lots of space glyphs */
+		aborted = !dumpglyphs(sf, &at->gi);
+	}
+	if (format != ff_type42 && format != ff_type42cid)
+	{
+		if (bsizes != NULL && !aborted)
+			ttfdumpbitmap(sf, at, bsizes);
+		if (bsizes != NULL && format == ff_none && at->msbitmaps)
+			ttfdumpbitmapscaling(sf, at, bsizes);
+	}
+	if (aborted)
+	{
+		AbortTTF(at, sf);
+		return(false);
+	}
+
+	sethead(&at->head, sf, at, format, bsizes);
+	sethhead(&at->hhead, &at->vhead, at, sf);
+	if (format == ff_none && at->otbbitmaps)
+		dummyloca(at);
+	else if (format != ff_otf && format != ff_otfcid && bf != bf_sfnt_dfont &&
+		(format != ff_none || (bsizes != NULL && !at->applemode && at->opentypemode)))
+		redoloca(at);
+	redohead(at);
+	if (format != ff_none || !at->applemode)	/* No 'hhea' table for apple bitmap-only fonts */
+		redohhead(at, false);
+	if (sf->hasvmetrics)
+	{
+		redohhead(at, true);
+	}
+	ttf_fftm_dump(sf, at);
+
+	if (format != ff_type42 && format != ff_type42cid && !sf->internal_temp)
+	{
+		initATTables(at, sf, format);
+	}
+	redomaxp(at, format);
+	if (format != ff_otf && format != ff_otfcid && format != ff_none)
+	{
+		if ((sf->gasp_cnt != 0 || !SFHasInstructions(sf))
+			&& format != ff_type42 && format != ff_type42cid)
+			dumpgasp(at, sf);
+		at->fpgmf = dumpstoredtable(sf, CHR('f', 'p', 'g', 'm'), &at->fpgmlen);
+		at->prepf = dumpstoredtable(sf, CHR('p', 'r', 'e', 'p'), &at->preplen);
+		at->cvtf = dumpstoredtable(sf, CHR('c', 'v', 't', ' '), &at->cvtlen);
+	}
+	for (tab = sf->ttf_tab_saved; tab != NULL; tab = tab->next)
+		tab->temp = dumpsavedtable(tab);
+	if (format != ff_type42 && format != ff_type42cid)
+	{
+		dumppost(at, sf, format);
+		dumpcmap(at, sf, format);
+
+		pfed_dump(at, sf);
+		tex_dump(at, sf);
+	}
+	if (sf->subfonts != NULL)
+	{
+		free(sf->glyphs); sf->glyphs = NULL;
+		sf->glyphcnt = sf->glyphmax = 0;
+	}
+	free(at->gi.bygid);
+	at->gi.gcnt = 0;
+
+	buildtablestructures(at, sf, format);
+	for (i = 0; i < at->tabdir.numtab; ++i)
+	{
+		struct taboff* tab = &at->tabdir.tabs[i];
+		at->tabdir.ordered[i] = tab;
+		at->tabdir.alpha[i] = tab;
+		/* This is the ordering of tables in ARIAL. I've no idea why it makes a */
+		/*  difference to order them, time to do a seek seems likely to be small, but */
+		/*  other people make a big thing about ordering them so I'll do it. */
+		/* I got bored after glyph. Adobe follows the same scheme for their otf fonts */
+		/*  so at least the world is consistant */
+		/* On the other hand, MS Font validator has a different idea. Oh well */
+		/* From: http://partners.adobe.com/asn/tech/type/opentype/recom.jsp	      */
+		/* TrueType Ordering							      */
+		/*  head, hhea, maxp, OS/2, hmtx, LTSH, VDMX, hdmx, cmap, fpgm, prep, cvt,    */
+		/*  loca, glyf, kern, name, post, gasp, PCLT, DSIG			      */
+		/* CFF in OpenType Ordering						      */
+		/*  head, hhea, maxp, OS/2, name, cmap, post, CFF, (other tables, as convenient) */
+		if (format == ff_otf || format == ff_otfcid)
+		{
+			tab->orderingval = tab->tag == CHR('h', 'e', 'a', 'd') ? 1 :
+				tab->tag == CHR('h', 'h', 'e', 'a') ? 2 :
+				tab->tag == CHR('m', 'a', 'x', 'p') ? 3 :
+				tab->tag == CHR('O', 'S', '/', '2') ? 4 :
+				tab->tag == CHR('n', 'a', 'm', 'e') ? 5 :
+				tab->tag == CHR('c', 'm', 'a', 'p') ? 6 :
+				tab->tag == CHR('p', 'o', 's', 't') ? 7 :
+				tab->tag == CHR('C', 'F', 'F', ' ') ? 8 :
+				tab->tag == CHR('G', 'D', 'E', 'F') ? 17 :
+				tab->tag == CHR('G', 'S', 'U', 'B') ? 18 :
+				tab->tag == CHR('G', 'P', 'O', 'S') ? 19 :
+				20;
+		}
+		else
+		{
+			tab->orderingval = tab->tag == CHR('h', 'e', 'a', 'd') ? 1 :
+				tab->tag == CHR('h', 'h', 'e', 'a') ? 2 :
+				tab->tag == CHR('m', 'a', 'x', 'p') ? 3 :
+				tab->tag == CHR('O', 'S', '/', '2') ? 4 :
+				tab->tag == CHR('h', 'm', 't', 'x') ? 5 :
+				tab->tag == CHR('L', 'T', 'S', 'H') ? 6 :
+				tab->tag == CHR('V', 'D', 'M', 'X') ? 7 :
+				tab->tag == CHR('h', 'd', 'm', 'x') ? 8 :
+				tab->tag == CHR('c', 'm', 'a', 'p') ? 9 :
+				tab->tag == CHR('f', 'p', 'g', 'm') ? 10 :
+				tab->tag == CHR('p', 'r', 'e', 'p') ? 11 :
+				tab->tag == CHR('c', 'v', 't', ' ') ? 12 :
+				tab->tag == CHR('l', 'o', 'c', 'a') ? 13 :
+				tab->tag == CHR('g', 'l', 'y', 'f') ? 14 :
+				tab->tag == CHR('k', 'e', 'r', 'n') ? 15 :
+				tab->tag == CHR('n', 'a', 'm', 'e') ? 16 :
+				tab->tag == CHR('p', 'o', 's', 't') ? 17 :
+				tab->tag == CHR('g', 'a', 's', 'p') ? 18 :
+				tab->tag == CHR('P', 'C', 'L', 'T') ? 19 :
+				tab->tag == CHR('D', 'S', 'I', 'G') ? 20 :
+				tab->tag == CHR('G', 'D', 'E', 'F') ? 21 :
+				tab->tag == CHR('G', 'S', 'U', 'B') ? 22 :
+				tab->tag == CHR('G', 'P', 'O', 'S') ? 23 :
+				24;
+		}
+	}
+
+	qsort(at->tabdir.ordered, at->tabdir.numtab, sizeof(struct taboff*), tcomp);
+	qsort(at->tabdir.alpha, i, sizeof(struct taboff*), tagcomp);
+
+	offset = sizeof(int32) + 4 * sizeof(int16) + at->tabdir.numtab * 4 * sizeof(int32);
+	for (i = 0; i < at->tabdir.numtab; ++i) if (at->tabdir.ordered[i]->data != NULL)
+	{
+		at->tabdir.ordered[i]->offset = offset;
+		offset += ((at->tabdir.ordered[i]->length + 3) >> 2) << 2;
+		at->tabdir.ordered[i]->checksum = filechecksum(at->tabdir.ordered[i]->data);
+	}
+	for (i = 0; i < at->tabdir.numtab; ++i) if (at->tabdir.ordered[i]->data == NULL)
+	{
+		struct taboff* tab = &at->tabdir.tabs[at->tabdir.ordered[i]->dup_of];
+		at->tabdir.ordered[i]->offset = tab->offset;
+		at->tabdir.ordered[i]->checksum = tab->checksum;
+	}
+
+	tab = SFFindTable(sf, CHR('c', 'v', 't', ' '));
+	if (tab != NULL)
+	{
+		if (at->oldcvt != NULL && at->oldcvtlen < tab->len)
+			tab->len = at->oldcvtlen;
+		else if (at->oldcvt == NULL)
+		{
+			/* We created a cvt table when we output the .notdef glyph */
+			/*  now that means AutoInstr thinks it no longer has a blank */
+			/*  slate to work with, and will complain, much to the user's */
+			/*  surprise.  So get rid of it */
+			struct ttf_table* prev = NULL;
+			for (tab = sf->ttf_tables; tab != NULL; prev = tab, tab = tab->next)
+				if (tab->tag == CHR('c', 'v', 't', ' '))
+					break;
+			if (tab != NULL)
+			{
+				if (prev == NULL)
+					sf->ttf_tables = tab->next;
+				else
+					prev->next = tab->next;
+				tab->next = NULL;
+				TtfTablesFree(tab);
+			}
+		}
+	}
+	return(true);
 }
 
 static char *Tag2String(uint32 tag) {

--- a/fontforgeexe/contextchain.c
+++ b/fontforgeexe/contextchain.c
@@ -1928,8 +1928,6 @@ static int WhichSections(struct contextchaindlg *ccd, GGadget *g) {
 return( sections );
 }
 
-
-//todo: sdn: memory corruption
 static void RenameClass(struct contextchaindlg* ccd, char* old, char* new, int sections)
 {
 	/* A class has been renamed. We should fix up all class rules that use */
@@ -1942,11 +1940,6 @@ static void RenameClass(struct contextchaindlg* ccd, char* old, char* new, int s
 	struct matrix_data* classrules = GMatrixEditGet(gclassrules, &rows);
 	int cols = GMatrixEditGetColCnt(gclassrules);
 	int ch;
-
-	//todo possible bug: they do not reset at the next iteration
-	//char* end_back = NULL;
-	//char* end_match = NULL;
-
 	char* pt;
 	char* last_name;
 	char* temp;

--- a/fontforgeexe/cvpalettes.c
+++ b/fontforgeexe/cvpalettes.c
@@ -1636,17 +1636,18 @@ static void CVLayers2Set(CharView *cv) {
     CVLayers2Reflow(cv, true);
 }
 
-static void Layers2Expose(CharView *cv,GWindow pixmap,GEvent *event) {
+static void Layers2Expose(CharView* cv, GWindow pixmap, GEvent* event)
+{
     int i, ll;
-    const char *str;
+    const char* str;
     GRect r, oldclip;
     struct _GImage base;
     GImage gi;
-    int as = (24*cv->b.sc->parent->ascent)/(cv->b.sc->parent->ascent+cv->b.sc->parent->descent);
+    int as = (24 * cv->b.sc->parent->ascent) / (cv->b.sc->parent->ascent + cv->b.sc->parent->descent);
     int leftOffset, layerCount;
 
-    if ( event->u.expose.rect.y+event->u.expose.rect.height<layer2.header_height )
-return;
+    if (event->u.expose.rect.y + event->u.expose.rect.height < layer2.header_height)
+        return;
 
     // Calculate the left offset (from the checkboxes)
     GGadgetGetSize(GWidgetGetControl(cvlayers2, CID_VGrid), &r);
@@ -1658,68 +1659,82 @@ return;
     r.y = layer2.header_height;
     r.height = r.height - layer2.header_height;
     GDrawPushClip(pixmap, &r, &oldclip);
-    GDrawFillRect(pixmap,&r,GDrawGetDefaultBackground(NULL));
+    GDrawFillRect(pixmap, &r, GDrawGetDefaultBackground(NULL));
 
     GDrawSetDither(NULL, false);	/* on 8 bit displays we don't want any dithering */
 
-    memset(&gi,0,sizeof(gi));
-    memset(&base,0,sizeof(base));
+    memset(&gi, 0, sizeof(gi));
+    memset(&base, 0, sizeof(base));
     gi.u.image = &base;
     base.image_type = it_index;
     base.clut = layer2.clut;
     base.trans = -1;
-    GDrawSetFont(pixmap,layer2.font);
+    GDrawSetFont(pixmap, layer2.font);
 
     // +2 for the defaults, +1 to show one extra (could be partially visible)
     layerCount = layer2.visible_layers + 2 + 1;
-    if (layerCount > layer2.current_layers) {
+    if (layerCount > layer2.current_layers)
+    {
         layerCount = layer2.current_layers;
     }
-    for (i = 0; i < layerCount; ++i) {
-	ll = i<2 ? i : i+layer2.offtop;
-	if ( ll==layer2.active ) {
+    for (i = 0; i < layerCount; ++i)
+    {
+        ll = i < 2 ? i : i + layer2.offtop;
+        if (ll == layer2.active)
+        {
             r.x = leftOffset;
             r.width = layer2.sb_start - r.x;
             r.y = layer2.header_height + i * CV_LAYERS2_LINE_HEIGHT;
-	    r.height = CV_LAYERS2_LINE_HEIGHT;
-	    GDrawFillRect(pixmap,&r,GDrawGetDefaultForeground(NULL));
-	}
+            r.height = CV_LAYERS2_LINE_HEIGHT;
+            GDrawFillRect(pixmap, &r, GDrawGetDefaultForeground(NULL));
+        }
         GDrawDrawLine(pixmap, r.x, layer2.header_height + i * CV_LAYERS2_LINE_HEIGHT,
-                      r.x + r.width, layer2.header_height + i * CV_LAYERS2_LINE_HEIGHT,
-		0x808080);
-	if ( i==0 || i==1 ) {
-	    str = i==0?_("Guide") : _("Back");
+            r.x + r.width, layer2.header_height + i * CV_LAYERS2_LINE_HEIGHT,
+            0x808080);
+
+        //todo monotty unify: allow background layer name
+        if (i == 0 || i == 1)
+        {
+            //str = i == 0 ? _("Guide") : _("Back");
+            str = i == 0 ? _("Guide") : _("Outline");
             GDrawDrawText8(pixmap, r.x + 2, layer2.header_height + i * CV_LAYERS2_LINE_HEIGHT + (CV_LAYERS2_LINE_HEIGHT - 12) / 2 + 12,
-		    (char *) str,-1,ll==layer2.active?0xffffff:GDrawGetDefaultForeground(NULL));
-	} else if ( layer2.offtop+i>=layer2.current_layers ) {
-    break;
-	} else if ( layer2.layers[layer2.offtop+i]!=NULL ) {
+                (char*)str, -1, ll == layer2.active ? 0xffffff : GDrawGetDefaultForeground(NULL));
+        }
+        else if (layer2.offtop + i >= layer2.current_layers)
+        {
+            break;
+        }
+        else if (layer2.layers[layer2.offtop + i] != NULL)
+        {
 #if 0
-	    // This is currently broken, and we do not have time to fix it.
-	    BDFChar *bdfc = layer2.layers[layer2.offtop+i];
-	    base.data = bdfc->bitmap;
-	    base.bytes_per_line = bdfc->bytes_per_line;
-	    base.width = bdfc->xmax-bdfc->xmin+1;
-	    base.height = bdfc->ymax-bdfc->ymin+1;
-	    GDrawDrawImage(pixmap,&gi,NULL,
-		    r.x+2+bdfc->xmin,
-                           layer2.header_height + i * CV_LAYERS2_LINE_HEIGHT + as - bdfc->ymax);
+            // This is currently broken, and we do not have time to fix it.
+            BDFChar* bdfc = layer2.layers[layer2.offtop + i];
+            base.data = bdfc->bitmap;
+            base.bytes_per_line = bdfc->bytes_per_line;
+            base.width = bdfc->xmax - bdfc->xmin + 1;
+            base.height = bdfc->ymax - bdfc->ymin + 1;
+            GDrawDrawImage(pixmap, &gi, NULL,
+                r.x + 2 + bdfc->xmin,
+                layer2.header_height + i * CV_LAYERS2_LINE_HEIGHT + as - bdfc->ymax);
 #else
-	    // This logic comes from CVInfoDrawText.
-	    const int layernamesz = 100;
-	    char layername[layernamesz+1];
-	    strncpy(layername,_("Guide"),layernamesz);
-	    int idx = layer2.offtop+i-1;
-	    if(idx >= 0 && idx < cv->b.sc->parent->layer_cnt) {
-	      strncpy(layername,cv->b.sc->parent->layers[idx].name,layernamesz);
-	    } else {
-	      fprintf(stderr, "Invalid layer!\n");
-	    }
-	    // And this comes from above.
+            // This logic comes from CVInfoDrawText.
+            const int layernamesz = 100;
+            char layername[layernamesz + 1];
+            strncpy(layername, _("Guide"), layernamesz);
+            int idx = layer2.offtop + i - 1;
+            if (idx >= 0 && idx < cv->b.sc->parent->layer_cnt)
+            {
+                strncpy(layername, cv->b.sc->parent->layers[idx].name, layernamesz);
+            }
+            else
+            {
+                fprintf(stderr, "Invalid layer!\n");
+            }
+            // And this comes from above.
             GDrawDrawText8(pixmap, r.x + 2, layer2.header_height + i * CV_LAYERS2_LINE_HEIGHT + (CV_LAYERS2_LINE_HEIGHT - 12) / 2 + 12,
-		    (char *) layername,-1,ll==layer2.active?0xffffff:GDrawGetDefaultForeground(NULL));
+                (char*)layername, -1, ll == layer2.active ? 0xffffff : GDrawGetDefaultForeground(NULL));
 #endif // 0
-	}
+        }
     }
     GDrawPopClip(pixmap, &oldclip);
 }

--- a/fontforgeexe/fontinfo.c
+++ b/fontforgeexe/fontinfo.c
@@ -7481,7 +7481,7 @@ static int lookups_e_h(GWindow gw, GEvent* event, int isgpos)
     if ((event->type == et_mouseup || event->type == et_mousedown) &&
         (event->u.mouse.button >= 4 && event->u.mouse.button <= 7))
     {
-        //todo mouse scroll don't work (gadget not found)
+        //todo monotty mouse scroll don't work (gadget not found)
 
         struct ggadget* gadget = GWidgetGetControl(gw, CID_LookupVSB + isgpos);
         return(GGadgetDispatchEvent(gadget, event));

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -6433,6 +6433,9 @@ GMenuItem2 helplist[] = {
 };
 
 GMenuItem fvpopupmenu[] = {
+
+	//todo monottyunify
+
 	{ { (unichar_t*)N_("Swap"), (GImage*)"filerevert.png", COLOR_DEFAULT, COLOR_DEFAULT, NULL, NULL, 0, 1, 0, 0, 0, 0, 1, 1, 0, 'V' }, '\0', ksm_control | ksm_shift, NULL, NULL, FVMenuSwap, MID_CharSwap },
 	{ { (unichar_t*)N_("Invite"), (GImage*)"filenew.png", COLOR_DEFAULT, COLOR_DEFAULT, NULL, NULL, 0, 1, 0, 0, 0, 0, 1, 1, 0, 'V' }, '\0', ksm_control | ksm_shift, NULL, NULL, FVMenuInvite, MID_CharInvite },
 	{ { (unichar_t*)N_("Reject"), (GImage*)"editcut.png", COLOR_DEFAULT, COLOR_DEFAULT, NULL, NULL, 0, 1, 0, 0, 0, 0, 1, 1, 0, 'V' }, '\0', ksm_control | ksm_shift, NULL, NULL, FVMenuReject, MID_CharReject },

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -276,14 +276,16 @@ static void FVDrawGlyph(GWindow pixmap, FontView* fv, int index, int forcebg)
 		GDrawFillRect(pixmap, &box, decor_color);
 	}
 	else
-		if (sc)
-		{
-			Color clr = sc->width == 1000  ?
-			//Color clr = (strncmp("NameMe", sc->name, 6) != 0) ?
-				(fv->b.selected[index] ? fvselcol : view_bgcol)
-				: 0xFF00FF;
-			GDrawFillRect(pixmap, &box, clr);
-		}else
+		//todo monotty unify
+		// mark cells with color if condition
+		//if (sc)
+		//{
+		//	Color clr = sc->width == 1000  ?
+		//	//Color clr = (strncmp("NameMe", sc->name, 6) != 0) ?
+		//		(fv->b.selected[index] ? fvselcol : view_bgcol)
+		//		: 0xFF00FF;
+		//	GDrawFillRect(pixmap, &box, clr);
+		//}else
 	if (index < fv->b.map->enccount && (fv->b.selected[index] || forcebg))
 	{
 		//box.x = j * fv->cbw + 1; box.width = fv->cbw - 1;
@@ -362,7 +364,7 @@ static void FVDrawGlyph(GWindow pixmap, FontView* fv, int index, int forcebg)
 				}
 				else if (decor)
 				{
-					//todo optimize
+					//todo monotty optimize
 					uint8 clr = brightness > 160 ? 0 : 0xff;
 
 					int bgr = ~clr;

--- a/fontforgeexe/savefontdlg.c
+++ b/fontforgeexe/savefontdlg.c
@@ -2575,7 +2575,10 @@ int SFGenerateFont(SplineFont* sf, int layer, int family, EncMap* map)
 		formattypes[ff_cff].disabled = true;
 		formattypes[ff_cffcid].disabled = true;
 		formattypes[ff_cid].disabled = true;
+		
+		//todo monotty unify
 		//formattypes[ff_ttf].disabled = true;
+
 		formattypes[ff_type42].disabled = true;
 		formattypes[ff_type42cid].disabled = true;
 		formattypes[ff_ttfsym].disabled = true;
@@ -2590,7 +2593,7 @@ int SFGenerateFont(SplineFont* sf, int layer, int family, EncMap* map)
 		formattypes[ff_ufo3].disabled = true;
 		if (ofs != ff_svg)
 		{
-			//todo unify
+			//todo monotty unify
 			//ofs = ff_ptype3;
 			ofs = ff_ttf;
 		}

--- a/fontforgeexe/savefontdlg.c
+++ b/fontforgeexe/savefontdlg.c
@@ -1431,7 +1431,7 @@ static void DoSave(struct gfc_data* d, unichar_t* path)
 		//GTextInfo* show_layer_menu_data = GGadgetGetListItemSelected(show_layer_menu_ctrl);
 		//layer = (intpt)show_layer_menu_data->userdata;
 		
-		//todo unify
+		//todo monotty unify
 		layer = ly_back;
 	}
 
@@ -1514,8 +1514,9 @@ static void DoSave(struct gfc_data* d, unichar_t* path)
 				break;
 		if (bit == 0 && !ttfscalewarned)
 		{
-			if (gwwv_ask(_("Non-standard Em-Size"), (const char**)buts, 0, 1, _("The convention is that TrueType fonts should have an Em-Size which is a power of 2. But this font has a size of %d. This is not an error, but you might consider altering the Em-Size with the Element->Font Info->General dialog.\nDo you wish to continue to generate your font in spite of this?"), val) == 1)
-				return;
+			//todo monotty unify
+			//if (gwwv_ask(_("Non-standard Em-Size"), (const char**)buts, 0, 1, _("The convention is that TrueType fonts should have an Em-Size which is a power of 2. But this font has a size of %d. This is not an error, but you might consider altering the Em-Size with the Element->Font Info->General dialog.\nDo you wish to continue to generate your font in spite of this?"), val) == 1)
+			//	return;
 			ttfscalewarned = true;
 		}
 	}


### PR DESCRIPTION
<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **New feature**
